### PR TITLE
feat: Add black and white theme option

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,12 +7,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Theme switcher
     themeToggle.addEventListener('click', () => {
-        document.body.classList.toggle('dark-mode');
-        // Update button text
         if (document.body.classList.contains('dark-mode')) {
+            // Switch to B&W mode
+            document.body.classList.remove('dark-mode');
+            document.body.classList.add('bw-mode');
             themeToggle.textContent = 'Toggle Light Mode';
-        } else {
+        } else if (document.body.classList.contains('bw-mode')) {
+            // Switch to Light mode
+            document.body.classList.remove('bw-mode');
             themeToggle.textContent = 'Toggle Dark Mode';
+        } else {
+            // Switch to Dark mode
+            document.body.classList.add('dark-mode');
+            themeToggle.textContent = 'Toggle B&W Mode';
         }
     });
 

--- a/style.css
+++ b/style.css
@@ -94,3 +94,33 @@ body.dark-mode #todo-list li {
 body.dark-mode .reminder-text {
     color: #ccc;
 }
+
+/* Black and White Mode */
+body.bw-mode {
+    background-color: #fff;
+    color: #000;
+}
+
+body.bw-mode .container {
+    background-color: #eee;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+body.bw-mode #todo-input {
+    background-color: #fff;
+    color: #000;
+    border-color: #999;
+}
+
+body.bw-mode #add-todo {
+    background-color: #000;
+    color: #fff;
+}
+
+body.bw-mode #todo-list li {
+    border-bottom-color: #999;
+}
+
+body.bw-mode .reminder-text {
+    color: #333;
+}


### PR DESCRIPTION
This commit introduces a new black and white theme to the application. The theme switcher now cycles through three themes: light, dark, and black and white.

The changes include:
- Added `bw-mode` CSS class and styles in `style.css`.
- Updated the theme switcher logic in `script.js` to cycle through the three themes.
- The button text now dynamically updates to indicate the next theme in the cycle.